### PR TITLE
Add word search tests

### DIFF
--- a/search/src/word_search.rs
+++ b/search/src/word_search.rs
@@ -59,10 +59,7 @@ mod tests {
 
     #[test]
     fn search_matches_complete_words() {
-        let posts = vec![
-            make_post(1, &["rust lang"]),
-            make_post(2, &["crust test"]),
-        ];
+        let posts = vec![make_post(1, &["rust lang"]), make_post(2, &["crust test"])];
 
         let engine = WordSearchEngine::new(posts);
         let results = engine.search("rust");

--- a/search/src/word_search.rs
+++ b/search/src/word_search.rs
@@ -26,3 +26,55 @@ impl SearchEngine for WordSearchEngine {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_post(id: u32, fields: &[&str]) -> SearchPostData {
+        SearchPostData {
+            id: id.to_string(),
+            fields: fields.iter().map(|s| s.to_string()).collect(),
+            meta: json!({ "id": id }),
+        }
+    }
+
+    #[test]
+    fn search_is_case_insensitive() {
+        let posts = vec![
+            make_post(1, &["Hello World"]),
+            make_post(2, &["rust language"]),
+        ];
+
+        let engine = WordSearchEngine::new(posts);
+        let results = engine.search("hello");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["id"], 1);
+
+        let results_upper = engine.search("RUST");
+        assert_eq!(results_upper.len(), 1);
+        assert_eq!(results_upper[0]["id"], 2);
+    }
+
+    #[test]
+    fn search_matches_complete_words() {
+        let posts = vec![
+            make_post(1, &["rust lang"]),
+            make_post(2, &["crust test"]),
+        ];
+
+        let engine = WordSearchEngine::new(posts);
+        let results = engine.search("rust");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["id"], 1);
+    }
+
+    #[test]
+    fn search_returns_empty_for_no_match() {
+        let posts = vec![make_post(1, &["hello world"])];
+        let engine = WordSearchEngine::new(posts);
+        let results = engine.search("absent");
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- cover `WordSearchEngine` with unit tests

## Testing
- `cargo test --workspace --all-targets --all-features` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684824bf93548321b96a06241bd45656