### PR TITLE
Fix clippy format args

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -27,11 +27,11 @@ impl MejiroConfig {
     /// Load blog configuration from YAML
     pub fn load_config(config_path: &str) -> Self {
         let contents = fs::read_to_string(config_path).unwrap_or_else(|e| {
-            panic!("❌ Could not read the config file: {} ({})", config_path, e);
+            panic!("❌ Could not read the config file: {config_path} ({e})");
         });
 
         serde_yaml::from_str(&contents).unwrap_or_else(|e| {
-            panic!("❌ Failed to parse YAML file '{}': {}", config_path, e);
+            panic!("❌ Failed to parse YAML file '{config_path}': {e}");
         })
     }
 
@@ -81,7 +81,7 @@ impl MejiroConfig {
         println!("\n🎉 Your Mejiro Blog structure:");
         for (name, desc) in entries {
             let padding = " ".repeat(longest_len - name.len() + 1);
-            println!("├── {}{}# {}", name, padding, desc);
+            println!("├── {name}{padding}# {desc}");
         }
     }
 

--- a/html/src/aside.rs
+++ b/html/src/aside.rs
@@ -8,16 +8,15 @@ pub fn aside_html(
         r#"
 <aside>
   <div class="logo">
-    <img src="{}" alt="Logo">
-    <span>{}</span>
+    <img src="{icon_path}" alt="Logo">
+    <span>{owner_name}</span>
   </div>
   <nav class="links">
     <a href="/">Home</a>
-    <a href="{}">GitHub</a>
-    <a href="{}">LinkedIn</a>
+    <a href="{owner_github_link}">GitHub</a>
+    <a href="{owner_linkedin_link}">LinkedIn</a>
   </nav>
 </aside>
-"#,
-        icon_path, owner_name, owner_github_link, owner_linkedin_link
+"#
     )
 }

--- a/html/src/footer.rs
+++ b/html/src/footer.rs
@@ -5,9 +5,8 @@ pub fn footer_html(site_title: &str) -> String {
     format!(
         r#"
 <footer>
-    <p>&copy; {} {}</p>
+    <p>&copy; {current_year} {site_title}</p>
 </footer>
-"#,
-        current_year, site_title
+"#
     )
 }

--- a/html/src/icon.rs
+++ b/html/src/icon.rs
@@ -13,8 +13,5 @@ pub fn icon_html(icon_path: &str) -> String {
         })
         .unwrap_or("image/png");
 
-    format!(
-        r#"<link rel="icon" href="{}" type="{}">"#,
-        icon_path, icon_type
-    )
+    format!(r#"<link rel="icon" href="{icon_path}" type="{icon_type}">"#)
 }

--- a/html/src/index.rs
+++ b/html/src/index.rs
@@ -15,13 +15,13 @@ pub fn index_html(
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{} Blog</title>
-  <link rel="stylesheet" href="{}">
-  {}
+  <title>{owner_name} Blog</title>
+  <link rel="stylesheet" href="{csv_file_path}">
+  {icon_html}
 </head>
 <body>
   <div class="container">
-    {}
+    {aside_html}
     <main>
       <div class="search-bar-wrapper">
         <i id="search-trigger" class="fas fa-search"></i>
@@ -33,37 +33,42 @@ pub fn index_html(
 
       <h1>Posts</h1>
       <ul id="post-list">
-"#,
-        owner_name, csv_file_path, icon_html, aside_html
+"#
     );
 
     // Loop through the posts and build the list
     for post in posts {
-        let summary_html = post.meta.tldr.as_ref().map_or(String::new(), |s| {
-            format!(r#"<p class="summary">{}</p>"#, s)
-        });
+        let summary_html = post
+            .meta
+            .tldr
+            .as_ref()
+            .map_or(String::new(), |s| format!(r#"<p class="summary">{s}</p>"#));
 
         let topics_html = if !post.meta.topics.is_empty() {
             let topics = post.meta.topics.join(", ");
-            format!(r#"<p class="topics">Tags: {}</p>"#, topics)
+            format!(r#"<p class="topics">Tags: {topics}</p>"#)
         } else {
             String::new()
         };
 
         let date_html = format!(
-            r#"<p class="published-at">Published at: {}</p>"#,
-            post.meta.published_at
+            r#"<p class="published-at">Published at: {published_at}</p>"#,
+            published_at = post.meta.published_at
         );
 
         index_html.push_str(&format!(
             r#"        <li>
-          <a href="posts/{}.html"><strong>{}</strong></a>
-          {}
-          {}
-          {}
+          <a href="posts/{name}.html"><strong>{title}</strong></a>
+          {summary_html}
+          {topics_html}
+          {date_html}
         </li>
 "#,
-            post.name, post.meta.title, summary_html, topics_html, date_html
+            name = post.name,
+            title = post.meta.title,
+            summary_html = summary_html,
+            topics_html = topics_html,
+            date_html = date_html
         ));
     }
 

--- a/html/src/metadata.rs
+++ b/html/src/metadata.rs
@@ -17,8 +17,8 @@ impl std::fmt::Display for BlogParseError {
             BlogParseError::MetadataNotFound => {
                 write!(f, "The markdown file is missing a metadata (YAML) header.")
             }
-            BlogParseError::YamlParseError(msg) => write!(f, "Failed to parse metadata: {}", msg),
-            BlogParseError::IoError(msg) => write!(f, "File error: {}", msg),
+            BlogParseError::YamlParseError(msg) => write!(f, "Failed to parse metadata: {msg}"),
+            BlogParseError::IoError(msg) => write!(f, "File error: {msg}"),
         }
     }
 }
@@ -131,11 +131,10 @@ This is the blog post content.
                     msg.contains("while parsing a flow sequence")
                         || msg.contains("did not find expected ',' or ']'")
                         || msg.contains("expected ',' or ']'"),
-                    "Unexpected error message: {}",
-                    msg
+                    "Unexpected error message: {msg}",
                 );
             }
-            _ => panic!("Expected YamlParseError, got {:?}", result),
+            _ => panic!("Expected YamlParseError, got {result:?}"),
         }
     }
 

--- a/html/src/post.rs
+++ b/html/src/post.rs
@@ -10,16 +10,16 @@ pub fn post_html(
     // Generate the header for the post
     let header_html = format!(
         r#"<header>
-  <h1>{}</h1>
+  <h1>{title}</h1>
   <div class="post-meta">
-    <span class="published-at">{}</span>
-    {}
+    <span class="published-at">{published_at}</span>
+    {summary}
   </div>
 </header>"#,
-        post.meta.title,
-        post.meta.published_at,
-        if let Some(tldr) = &post.meta.tldr {
-            format!(r#"<p class="summary">{}</p>"#, tldr)
+        title = post.meta.title,
+        published_at = post.meta.published_at,
+        summary = if let Some(tldr) = &post.meta.tldr {
+            format!(r#"<p class="summary">{tldr}</p>"#)
         } else {
             String::new()
         }
@@ -32,30 +32,30 @@ pub fn post_html(
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{}</title>
-  <link rel="stylesheet" href="{}">
-  {}
+  <title>{title}</title>
+  <link rel="stylesheet" href="{css_file_path}">
+  {icon_html}
 </head>
 <body>
   <div class="container">
-    {}
+    {aside_html}
     <main>
-      {}
+      {header_html}
       <article>
-        {}
+        {body}
       </article>
     </main>
   </div>
-  {}
+  {footer_html}
 </body>
 </html>
 "#,
-        post.meta.title,
-        css_file_path,
-        icon_html,
-        aside_html,
-        header_html,
-        post.html_body,
-        footer_html
+        title = post.meta.title,
+        css_file_path = css_file_path,
+        icon_html = icon_html,
+        aside_html = aside_html,
+        header_html = header_html,
+        body = post.html_body,
+        footer_html = footer_html
     )
 }

--- a/mejiro-cli/src/compile.rs
+++ b/mejiro-cli/src/compile.rs
@@ -48,17 +48,19 @@ pub fn compile(input_dir: &str, output_dir: &str, config_path: &str) {
         match Post::from_markdown_file(entry.path()) {
             Ok(Some(post)) => posts.push(post),
             Ok(None) => {
-                println!("Skipping unpublished post: {}", entry.path().display());
+                let path = entry.path().display();
+                println!("Skipping unpublished post: {path}");
             }
             Err(e) => {
-                eprintln!("Error parsing {}: {}", entry.path().display(), e);
+                let path = entry.path().display();
+                eprintln!("Error parsing {path}: {e}");
             }
         }
     }
     posts.sort_by(|a, b| b.meta.published_at.cmp(&a.meta.published_at));
 
     // Build post pages
-    let icon_path_rel = format!("../{}", icon_file_name);
+    let icon_path_rel = format!("../{icon_file_name}");
     let aside = html::aside_html(
         &config.owner.name,
         &config.owner.github_link,
@@ -90,7 +92,7 @@ pub fn compile(input_dir: &str, output_dir: &str, config_path: &str) {
 
     let post_paths: Vec<String> = posts
         .iter()
-        .map(|post| format!("{}.html", post.name))
+        .map(|post| format!("{name}.html", name = post.name))
         .collect();
 
     println!("\nOutput directory structure:");
@@ -105,15 +107,16 @@ pub fn compile(input_dir: &str, output_dir: &str, config_path: &str) {
     // Show top/bottom posts only if many
     if post_paths.len() > 10 {
         for path in &post_paths[..3] {
-            println!("│   ├── {}", path);
+            println!("│   ├── {path}");
         }
-        println!("│   ├── ... ({} posts omitted)", post_paths.len() - 6);
+        let omitted = post_paths.len() - 6;
+        println!("│   ├── ... ({omitted} posts omitted)");
         for path in &post_paths[post_paths.len() - 3..] {
-            println!("│   ├── {}", path);
+            println!("│   ├── {path}");
         }
     } else {
         for path in &post_paths {
-            println!("│   ├── {}", path);
+            println!("│   ├── {path}");
         }
     }
 
@@ -126,11 +129,11 @@ fn css_filename_with_hash(css_path: &Path) -> Option<String> {
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
         let hash = hasher.finalize();
-        let hash_hex = format!("{:x}", hash);
+        let hash_hex = format!("{hash:x}");
 
-        Some(format!("style.{}.css", &hash_hex[..8]))
+        Some(format!("style.{hash}.css", hash = &hash_hex[..8]))
     } else {
-        eprintln!("CSS file not found: {:?}", css_path);
+        eprintln!("CSS file not found: {css_path:?}");
         None
     }
 }
@@ -139,7 +142,7 @@ fn copy_file(src: &Path, dest: &Path, description: &str) -> std::io::Result<()> 
     if src.exists() {
         fs::copy(src, dest)?;
     } else {
-        eprintln!("{} not found: {:?}", description, src);
+        eprintln!("{description} not found: {src:?}");
     }
     Ok(())
 }
@@ -157,7 +160,7 @@ fn copy_images(src_dir: &Path, dest_dir: &Path) {
             }
         }
     } else {
-        eprintln!("Images directory not found: {:?}", src_dir);
+        eprintln!("Images directory not found: {src_dir:?}");
     }
 }
 
@@ -170,10 +173,12 @@ fn build_post_pages(
     css_filename: &str,
 ) {
     for post in posts {
-        let output_path = output_dir.join("posts").join(format!("{}.html", post.name));
+        let output_path = output_dir
+            .join("posts")
+            .join(format!("{name}.html", name = post.name));
         fs::create_dir_all(output_path.parent().unwrap()).unwrap();
 
-        let css_relative_path = format!("../{}", css_filename);
+        let css_relative_path = format!("../{css_filename}");
         let post_html = html::post_html(post, aside, footer, icon, &css_relative_path);
         fs::write(&output_path, post_html).unwrap();
     }

--- a/mejiro-cli/src/image.rs
+++ b/mejiro-cli/src/image.rs
@@ -11,7 +11,8 @@ pub fn add(config_path: &str, image_path: &str) -> io::Result<()> {
     fs::create_dir_all(dest_dir)?;
     let dest = dest_dir.join(src.file_name().unwrap());
     fs::copy(src, &dest)?;
-    println!("✅ Added image: {}", dest.display());
+    let path = dest.display();
+    println!("✅ Added image: {path}");
     Ok(())
 }
 
@@ -19,7 +20,8 @@ pub fn list(config_path: &str) {
     let cfg = MejiroConfig::load_config(config_path);
     let dir = Path::new(&cfg.images_dir);
     if !dir.exists() {
-        eprintln!("❌ images directory not found: {}", dir.display());
+        let path = dir.display();
+        eprintln!("❌ images directory not found: {path}");
         return;
     }
     for entry in WalkDir::new(dir)
@@ -28,7 +30,8 @@ pub fn list(config_path: &str) {
         .filter(|e| e.file_type().is_file())
     {
         if let Ok(rel) = entry.path().strip_prefix(dir) {
-            println!("{}", rel.display());
+            let rel_path = rel.display();
+            println!("{rel_path}");
         }
     }
 }

--- a/mejiro-cli/src/list.rs
+++ b/mejiro-cli/src/list.rs
@@ -26,8 +26,8 @@ pub fn list(input_dir: &str, all: bool) {
             continue;
         }
         println!("---");
-        println!("name: {}", name);
+        println!("name: {name}");
         let yaml = serde_yaml::to_string(&meta).unwrap_or_default();
-        print!("{}", yaml);
+        print!("{yaml}");
     }
 }

--- a/mejiro-cli/src/new.rs
+++ b/mejiro-cli/src/new.rs
@@ -12,7 +12,8 @@ pub fn new(output_dir: &str) {
     // Check and create the output directory if it doesn't exist
     if !output_path.exists() {
         fs::create_dir_all(output_path).expect("Failed to create output directory");
-        println!("Created output directory: {}", output_path.display());
+        let path = output_path.display();
+        println!("Created output directory: {path}");
     }
 
     let date = Utc::now().format("%Y%m%d").to_string();
@@ -22,7 +23,7 @@ pub fn new(output_dir: &str) {
         .map(char::from)
         .collect();
 
-    let filename = format!("{}-{}.md", date, rand_suffix);
+    let filename = format!("{date}-{rand_suffix}.md");
     let filepath = output_path.join(&filename);
 
     let today = Utc::now().format("%Y-%m-%d").to_string();
@@ -35,14 +36,12 @@ pub fn new(output_dir: &str) {
     };
 
     let yaml_frontmatter = serde_yaml::to_string(&meta).expect("Failed to serialize frontmatter");
-    let content = format!(
-        "---\n{}---\n\n# New Post\n\nWrite your content here!\n",
-        yaml_frontmatter
-    );
+    let content = format!("---\n{yaml_frontmatter}---\n\n# New Post\n\nWrite your content here!\n");
 
     let mut file = fs::File::create(&filepath).expect("Failed to create file");
     file.write_all(content.as_bytes())
         .expect("Failed to write to file");
 
-    println!("✅ New blog post created: {}", filepath.display());
+    let path = filepath.display();
+    println!("✅ New blog post created: {path}");
 }

--- a/mejiro-cli/src/posts_json.rs
+++ b/mejiro-cli/src/posts_json.rs
@@ -14,7 +14,7 @@ pub fn generate_posts_json(posts: &[Post], output_dir: &str) {
             title: post.meta.title.clone(),
             tags: post.meta.topics.clone(),
             tldr: post.meta.tldr.clone(),
-            path: format!("posts/{}.html", post.name),
+            path: format!("posts/{name}.html", name = post.name),
             published_at: post.meta.published_at.clone(),
         };
         let fields = vec![


### PR DESCRIPTION
## Summary
- fix `clippy::uninlined_format_args` warnings across the workspace

## Testing
- `cargo test` *(fails: couldn't fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6889617b01508321b0a30dd4c8e55389